### PR TITLE
Allow ICU to be disabled with cli switch

### DIFF
--- a/GenCpp.fu
+++ b/GenCpp.fu
@@ -23,8 +23,15 @@ public class GenCpp : GenCCpp
 	bool UsingStringViewLiterals;
 	bool HasEnumFlags;
 	bool StringReplace;
+	bool UseIcuUnicode = true;
 
 	protected override string GetTargetName() => "C++";
+
+	public GenCpp UseIcu!(bool useIcu)
+	{
+		UseIcuUnicode = useIcu;
+		return this;
+	}
 
 	protected override void IncludeStdInt!()
 	{
@@ -568,13 +575,26 @@ public class GenCpp : GenCCpp
 			WriteArgsInParentheses(method, args);
 	}
 
-	void WriteStringToLowerUpper!(FuExpr obj, string name)
+	void WriteStringToLowerUpper!(FuExpr obj, string icuname, string stdname)
 	{
-		Include("string");
-		Include("unicode/unistr.h");
-		Write("[](icu::StringPiece s) { std::string result; return icu::UnicodeString::fromUTF8(s).to");
-		Write(name);
-		WriteCall("er().toUTF8String(result); }", obj);
+		if (UseIcuUnicode) {
+			Include("string");
+			Include("unicode/unistr.h");
+			Write("[](icu::StringPiece s) { std::string result; return icu::UnicodeString::fromUTF8(s).to");
+			Write(icuname);
+			WriteCall("().toUTF8String(result); }", obj);
+		} else {
+			Include("algorithm");
+			Include("cctype");
+			Write("[&] { std::string data = std::string{");
+			obj.Accept(this, FuPriority.Argument);
+			Write("}; ");
+			Write("std::transform(data.begin(), data.end(), data.begin(), ");
+			Write("[](unsigned char c) { return std::to");
+			Write(stdname);
+			Write("(c); }); ");
+			Write("return data; }()");
+		}
 	}
 
 	void WriteAllAnyContains!(string function, FuExpr obj, List<FuExpr#> args)
@@ -818,10 +838,10 @@ public class GenCpp : GenCCpp
 			WriteStringMethod(obj, "substr", method, args);
 			break;
 		case FuId.StringToLower:
-			WriteStringToLowerUpper(obj, "Low");
+			WriteStringToLowerUpper(obj, "Lower", "lower");
 			break;
 		case FuId.StringToUpper:
-			WriteStringToLowerUpper(obj, "Upp");
+			WriteStringToLowerUpper(obj, "Upper", "upper");
 			break;
 		case FuId.ArrayBinarySearchAll:
 		case FuId.ArrayBinarySearchPart:

--- a/libfut.hpp
+++ b/libfut.hpp
@@ -2265,6 +2265,7 @@ class GenCpp : public GenCCpp
 {
 public:
 	GenCpp() = default;
+	const GenCpp * useIcu(bool useIcu);
 	void writeProgram(const FuProgram * program) override;
 protected:
 	std::string_view getTargetName() const override;
@@ -2315,6 +2316,7 @@ private:
 	bool usingStringViewLiterals;
 	bool hasEnumFlags;
 	bool stringReplace;
+	bool useIcuUnicode = true;
 	void startMethodCall(const FuExpr * obj);
 	void writeCamelCaseNotKeyword(std::string_view name);
 	void writeCollectionType(std::string_view name, const FuType * elementType);
@@ -2328,7 +2330,7 @@ private:
 	void writePtrRange(const FuExpr * obj, const FuExpr * index, const FuExpr * count);
 	void writeNotRawStringLiteral(const FuExpr * obj, FuPriority priority);
 	void writeStringMethod(const FuExpr * obj, std::string_view name, const FuMethod * method, const std::vector<std::shared_ptr<FuExpr>> * args);
-	void writeStringToLowerUpper(const FuExpr * obj, std::string_view name);
+	void writeStringToLowerUpper(const FuExpr * obj, std::string_view icuname, std::string_view stdname);
 	void writeAllAnyContains(std::string_view function, const FuExpr * obj, const std::vector<std::shared_ptr<FuExpr>> * args);
 	void writeCollectionMethod(const FuExpr * obj, std::string_view name, const std::vector<std::shared_ptr<FuExpr>> * args);
 	void writeCString(const FuExpr * expr);


### PR DESCRIPTION
As title says. I added a `--no-icu` switch which falls back to using the std ascii-only functions. 

I even agree that ICU should perhaps be the default, however I don't think it's proper to justify bringing in such a heavy and hard to include dependency if you are just needing to do ascii string comparison. I appreciate your note about it being easy to install a MinGW package, but for win32 developers using Visual Studio it is not so simple. There is an vcpkg package to pull in and build icu from source in your project, but this requires you to be using cmake (not msvc/vcproj) and still requires some fiddling.

Let me know if you agree or disagree.