### PR TITLE
Drop ICU dependency on Win32 & fix min/max macros

### DIFF
--- a/GenCpp.fu
+++ b/GenCpp.fu
@@ -23,6 +23,7 @@ public class GenCpp : GenCCpp
 	bool UsingStringViewLiterals;
 	bool HasEnumFlags;
 	bool StringReplace;
+	bool StringToLowerUpper;
 
 	protected override string GetTargetName() => "C++";
 
@@ -568,15 +569,6 @@ public class GenCpp : GenCCpp
 			WriteArgsInParentheses(method, args);
 	}
 
-	void WriteStringToLowerUpper!(FuExpr obj, string name)
-	{
-		Include("string");
-		Include("unicode/unistr.h");
-		Write("[](icu::StringPiece s) { std::string result; return icu::UnicodeString::fromUTF8(s).to");
-		Write(name);
-		WriteCall("er().toUTF8String(result); }", obj);
-	}
-
 	void WriteAllAnyContains!(string function, FuExpr obj, List<FuExpr#> args)
 	{
 		Include("algorithm");
@@ -818,10 +810,12 @@ public class GenCpp : GenCCpp
 			WriteStringMethod(obj, "substr", method, args);
 			break;
 		case FuId.StringToLower:
-			WriteStringToLowerUpper(obj, "Low");
+			this.StringToLowerUpper = true;
+			WriteCall("FuString_ToLower", obj);
 			break;
 		case FuId.StringToUpper:
-			WriteStringToLowerUpper(obj, "Upp");
+			this.StringToLowerUpper = true;
+			WriteCall("FuString_ToUpper", obj);
 			break;
 		case FuId.ArrayBinarySearchAll:
 		case FuId.ArrayBinarySearchPart:
@@ -1998,6 +1992,80 @@ public class GenCpp : GenCCpp
 			WriteLine("\ti = j + oldValue.size();");
 			WriteCharLine('}');
 			CloseBlock();
+		}
+		if (this.StringToLowerUpper) {
+			WriteNewLine();
+			WriteLine("#if defined(_WIN32)");
+			WriteNewLine();
+			WriteLine("#include <Windows.h>");
+			WriteNewLine();
+			WriteLine("inline std::string FuString_WideToUtf8(std::wstring const& wstr)");
+			OpenBlock();
+			WriteLine("int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);");
+			WriteLine("std::string strTo(sizeNeeded, 0);");
+			WriteLine("WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], sizeNeeded, NULL, NULL);");
+			WriteLine("return strTo;");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("inline std::wstring FuString_Utf8ToWide(std::string const& str)");
+			OpenBlock();
+			WriteLine("int sizeNeeded = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);");
+			WriteLine("std::wstring strTo(sizeNeeded, 0);");
+			WriteLine("MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &strTo[0], sizeNeeded);");
+			WriteLine("return strTo;");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("static std::string FuString_Win32LCMap(std::string str, DWORD flags)");
+			OpenBlock();
+			WriteLine("std::wstring wide = FuString_Utf8ToWide(str);");
+			WriteLine("int sizeNeeded = LCMapStringEx(");
+			WriteLine("\tLOCALE_NAME_SYSTEM_DEFAULT, // lpLocaleName");
+			WriteLine("\tLCMAP_LINGUISTIC_CASING | flags, // dwMapFlags");
+			WriteLine("\twide.c_str(), // lpSrcStr");
+			WriteLine("\twide.length(), // cchSrc");
+			WriteLine("\t0, // lpDestStr");
+			WriteLine("\t0, // cchDest");
+			WriteLine("\tNULL, NULL, NULL);");
+			WriteLine("std::wstring strTo(sizeNeeded, 0);");
+			WriteLine("LCMapStringEx(");
+			WriteLine("\tLOCALE_NAME_SYSTEM_DEFAULT, // lpLocaleName");
+			WriteLine("\tLCMAP_LINGUISTIC_CASING | flags, // dwMapFlags");
+			WriteLine("\twide.c_str(), // lpSrcStr");
+			WriteLine("\twide.length(), // cchSrc");
+			WriteLine("\t&strTo[0], // lpDestStr");
+			WriteLine("\tsizeNeeded, // cchDest");
+			WriteLine("\tNULL, NULL, NULL);");
+			WriteLine("return FuString_WideToUtf8(strTo);");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("static std::string FuString_ToUpper(std::string_view str)");
+			OpenBlock();
+			WriteLine("\treturn FuString_Win32LCMap(std::string{ str }, LCMAP_UPPERCASE);");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("static std::string FuString_ToLower(std::string_view str)");
+			OpenBlock();
+			WriteLine("\treturn FuString_Win32LCMap(std::string{ str }, LCMAP_LOWERCASE);");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("#else");
+			WriteNewLine();
+			WriteLine("#include <unicode/unistr.h>");
+			WriteNewLine();
+			WriteLine("static std::string FuString_ToUpper(std::string_view str)");
+			OpenBlock();
+			WriteLine("\tstd::string result;");
+			WriteLine("\treturn icu::UnicodeString::fromUTF8(s).toUpper().toUTF8String(result);");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("static std::string FuString_ToLower(std::string_view str)");
+			OpenBlock();
+			WriteLine("\tstd::string result;");
+			WriteLine("\treturn icu::UnicodeString::fromUTF8(s).toLower().toUTF8String(result);");
+			CloseBlock();
+			WriteNewLine();
+			WriteLine("#endif");
+
 		}
 		CloseStringWriter();
 		CloseFile();

--- a/libfut.cpp
+++ b/libfut.cpp
@@ -6,7 +6,7 @@
 #include <format>
 #include "libfut.hpp"
 
-static std::string FuString_replace(std::string_view s, std::string_view oldValue, std::string_view newValue)
+static std::string FuString_Replace(std::string_view s, std::string_view oldValue, std::string_view newValue)
 {
 	std::string result;
 	result.reserve(s.size());
@@ -2932,7 +2932,7 @@ void FuParser::checkXcrementParent()
 std::shared_ptr<FuLiteralDouble> FuParser::parseDouble()
 {
 	double d;
-	if (![&] { char *ciend; d = std::strtod(FuString_replace(getLexeme(), "_", "").data(), &ciend); return *ciend == '\0'; }())
+	if (![&] { char *ciend; d = std::strtod(FuString_Replace(getLexeme(), "_", "").data(), &ciend); return *ciend == '\0'; }())
 		reportError("Invalid floating-point number");
 	std::shared_ptr<FuLiteralDouble> result = std::make_shared<FuLiteralDouble>();
 	result->line = this->line;
@@ -2953,7 +2953,7 @@ std::shared_ptr<FuInterpolatedString> FuParser::parseInterpolatedString()
 	std::shared_ptr<FuInterpolatedString> result = std::make_shared<FuInterpolatedString>();
 	result->line = this->line;
 	do {
-		std::string prefix{FuString_replace(this->stringValue, "{{", "{")};
+		std::string prefix{FuString_Replace(this->stringValue, "{{", "{")};
 		nextToken();
 		std::shared_ptr<FuExpr> arg = parseExpr();
 		std::shared_ptr<FuExpr> width = eat(FuToken::comma) ? parseExpr() : nullptr;
@@ -2972,7 +2972,7 @@ std::shared_ptr<FuInterpolatedString> FuParser::parseInterpolatedString()
 		check(FuToken::rightBrace);
 	}
 	while (readString(true) == FuToken::interpolatedString);
-	result->suffix = FuString_replace(this->stringValue, "{{", "{");
+	result->suffix = FuString_Replace(this->stringValue, "{{", "{");
 	nextToken();
 	return result;
 }
@@ -13542,15 +13542,6 @@ void GenCpp::writeStringMethod(const FuExpr * obj, std::string_view name, const 
 		writeArgsInParentheses(method, args);
 }
 
-void GenCpp::writeStringToLowerUpper(const FuExpr * obj, std::string_view name)
-{
-	include("string");
-	include("unicode/unistr.h");
-	write("[](icu::StringPiece s) { std::string result; return icu::UnicodeString::fromUTF8(s).to");
-	write(name);
-	writeCall("er().toUTF8String(result); }", obj);
-}
-
 void GenCpp::writeAllAnyContains(std::string_view function, const FuExpr * obj, const std::vector<std::shared_ptr<FuExpr>> * args)
 {
 	include("algorithm");
@@ -13789,10 +13780,12 @@ void GenCpp::writeCallExpr(const FuExpr * obj, const FuMethod * method, const st
 		writeStringMethod(obj, "substr", method, args);
 		break;
 	case FuId::stringToLower:
-		writeStringToLowerUpper(obj, "Low");
+		this->stringToLowerUpper = true;
+		writeCall("FuString_ToLower", obj);
 		break;
 	case FuId::stringToUpper:
-		writeStringToLowerUpper(obj, "Upp");
+		this->stringToLowerUpper = true;
+		writeCall("FuString_ToUpper", obj);
 		break;
 	case FuId::arrayBinarySearchAll:
 	case FuId::arrayBinarySearchPart:
@@ -14951,6 +14944,79 @@ void GenCpp::writeProgram(const FuProgram * program)
 		writeLine("\ti = j + oldValue.size();");
 		writeCharLine('}');
 		closeBlock();
+	}
+	if (this->stringToLowerUpper) {
+		writeNewLine();
+		writeLine("#if defined(_WIN32)");
+		writeNewLine();
+		writeLine("#include <Windows.h>");
+		writeNewLine();
+		writeLine("inline std::string FuString_WideToUtf8(std::wstring const& wstr)");
+		openBlock();
+		writeLine("int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);");
+		writeLine("std::string strTo(sizeNeeded, 0);");
+		writeLine("WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], sizeNeeded, NULL, NULL);");
+		writeLine("return strTo;");
+		closeBlock();
+		writeNewLine();
+		writeLine("inline std::wstring FuString_Utf8ToWide(std::string const& str)");
+		openBlock();
+		writeLine("int sizeNeeded = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);");
+		writeLine("std::wstring strTo(sizeNeeded, 0);");
+		writeLine("MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &strTo[0], sizeNeeded);");
+		writeLine("return strTo;");
+		closeBlock();
+		writeNewLine();
+		writeLine("static std::string FuString_Win32LCMap(std::string str, DWORD flags)");
+		openBlock();
+		writeLine("std::wstring wide = FuString_Utf8ToWide(str);");
+		writeLine("int sizeNeeded = LCMapStringEx(");
+		writeLine("\tLOCALE_NAME_SYSTEM_DEFAULT, // lpLocaleName");
+		writeLine("\tLCMAP_LINGUISTIC_CASING | flags, // dwMapFlags");
+		writeLine("\twide.c_str(), // lpSrcStr");
+		writeLine("\twide.length(), // cchSrc");
+		writeLine("\t0, // lpDestStr");
+		writeLine("\t0, // cchDest");
+		writeLine("\tNULL, NULL, NULL);");
+		writeLine("std::wstring strTo(sizeNeeded, 0);");
+		writeLine("LCMapStringEx(");
+		writeLine("\tLOCALE_NAME_SYSTEM_DEFAULT, // lpLocaleName");
+		writeLine("\tLCMAP_LINGUISTIC_CASING | flags, // dwMapFlags");
+		writeLine("\twide.c_str(), // lpSrcStr");
+		writeLine("\twide.length(), // cchSrc");
+		writeLine("\t&strTo[0], // lpDestStr");
+		writeLine("\tsizeNeeded, // cchDest");
+		writeLine("\tNULL, NULL, NULL);");
+		writeLine("return FuString_WideToUtf8(strTo);");
+		closeBlock();
+		writeNewLine();
+		writeLine("static std::string FuString_ToUpper(std::string_view str)");
+		openBlock();
+		writeLine("\treturn FuString_Win32LCMap(std::string{ str }, LCMAP_UPPERCASE);");
+		closeBlock();
+		writeNewLine();
+		writeLine("static std::string FuString_ToLower(std::string_view str)");
+		openBlock();
+		writeLine("\treturn FuString_Win32LCMap(std::string{ str }, LCMAP_LOWERCASE);");
+		closeBlock();
+		writeNewLine();
+		writeLine("#else");
+		writeNewLine();
+		writeLine("#include <unicode/unistr.h>");
+		writeNewLine();
+		writeLine("static std::string FuString_ToUpper(std::string_view str)");
+		openBlock();
+		writeLine("\tstd::string result;");
+		writeLine("\treturn icu::UnicodeString::fromUTF8(s).toUpper().toUTF8String(result);");
+		closeBlock();
+		writeNewLine();
+		writeLine("static std::string FuString_ToLower(std::string_view str)");
+		openBlock();
+		writeLine("\tstd::string result;");
+		writeLine("\treturn icu::UnicodeString::fromUTF8(s).toLower().toUTF8String(result);");
+		closeBlock();
+		writeNewLine();
+		writeLine("#endif");
 	}
 	closeStringWriter();
 	closeFile();

--- a/libfut.hpp
+++ b/libfut.hpp
@@ -2315,6 +2315,7 @@ private:
 	bool usingStringViewLiterals;
 	bool hasEnumFlags;
 	bool stringReplace;
+	bool stringToLowerUpper;
 	void startMethodCall(const FuExpr * obj);
 	void writeCamelCaseNotKeyword(std::string_view name);
 	void writeCollectionType(std::string_view name, const FuType * elementType);
@@ -2328,7 +2329,6 @@ private:
 	void writePtrRange(const FuExpr * obj, const FuExpr * index, const FuExpr * count);
 	void writeNotRawStringLiteral(const FuExpr * obj, FuPriority priority);
 	void writeStringMethod(const FuExpr * obj, std::string_view name, const FuMethod * method, const std::vector<std::shared_ptr<FuExpr>> * args);
-	void writeStringToLowerUpper(const FuExpr * obj, std::string_view name);
 	void writeAllAnyContains(std::string_view function, const FuExpr * obj, const std::vector<std::shared_ptr<FuExpr>> * args);
 	void writeCollectionMethod(const FuExpr * obj, std::string_view name, const std::vector<std::shared_ptr<FuExpr>> * args);
 	void writeCString(const FuExpr * expr);


### PR DESCRIPTION
As discussed in #145. 

If `_WIN32` and `UNICODE` are defined, it will use the win32 functions for ToLower/ToUpper instead of ICU.

Also, when including the `Windows.h` header, std::min and std::max conflict with the min/max windows macros, so I've wrapped them in parenthesis to fix this.