### PR TITLE
fix cpp TryParse in MSVC STL

### DIFF
--- a/GenCpp.fu
+++ b/GenCpp.fu
@@ -1974,8 +1974,8 @@ public class GenCpp : GenCCpp
 			WriteLine("template <class T, class... Args>");
 			WriteLine("bool FuNumber_TryParse(T &number, std::string_view s, Args... args)");
 			OpenBlock();
-			WriteLine("const char *end = s.begin() + s.size();");
-			WriteLine("auto result = std::from_chars(s.begin(), end, number, args...);");
+			WriteLine("const char *end = s.data() + s.size();");
+			WriteLine("auto result = std::from_chars(s.data(), end, number, args...);");
 			WriteLine("return result.ec == std::errc{} && result.ptr == end;");
 			CloseBlock();
 		}


### PR DESCRIPTION
Fut generates the following cpp code for tryparse

```cpp
template <class T, class... Args>
bool FuNumber_TryParse(T &number, std::string_view s, Args... args)
{
	const char *end = s.begin() + s.size();
	auto result = std::from_chars(s.begin(), end, number, args...);
	return result.ec == std::errc{} && result.ptr == end;
}
```

This errors using the microsoft STL
```
'initializing': cannot convert from 'std::_String_view_iterator<_Traits>' to 'const char *'
```

Solution is to use `std::string_view::data` instead of `std::string_view::begin`, as shown by the [cppreference example](https://en.cppreference.com/w/cpp/utility/from_chars)
https://godbolt.org/z/evPGMxEnW