### PR TITLE
Escape start and end braces in interpolated strings

### DIFF
--- a/GenBase.fu
+++ b/GenBase.fu
@@ -530,6 +530,15 @@ public abstract class GenBase : FuVisitor
 		}
 	}
 
+	protected void WriteDoublingBraces!(string s)
+	{
+		foreach (int c in s) {
+			if (c == '{' || c == '}')
+				WriteChar(c);
+			WriteChar(c);
+		}
+	}
+
 	protected virtual void WritePrintfWidth!(FuInterpolatedPart part)
 	{
 		if (part.WidthExpr != null)

--- a/GenCpp.fu
+++ b/GenCpp.fu
@@ -77,11 +77,11 @@ public class GenCpp : GenCCpp
 		Include("format");
 		Write("std::format(\"");
 		foreach (FuInterpolatedPart part in expr.Parts) {
-			WriteDoubling(part.Prefix, '{');
+			WriteDoublingBraces(part.Prefix);
 			WriteChar('{');
 			WritePyFormat(part);
 		}
-		WriteDoubling(expr.Suffix, '{');
+		WriteDoublingBraces(expr.Suffix);
 		WriteChar('"');
 		WriteInterpolatedStringArgs(expr);
 		WriteChar(')');

--- a/GenCs.fu
+++ b/GenCs.fu
@@ -354,7 +354,7 @@ public class GenCs : GenTyped
 		}
 		Write("$\"");
 		foreach (FuInterpolatedPart part in expr.Parts) {
-			WriteDoubling(part.Prefix, '{');
+			WriteDoublingBraces(part.Prefix);
 			WriteChar('{');
 			if (part.Format == 'U' || part.Format == 'u')
 				WriteCall("char.ConvertFromUtf32", part.Argument);
@@ -372,7 +372,7 @@ public class GenCs : GenTyped
 			}
 			WriteChar('}');
 		}
-		WriteDoubling(expr.Suffix, '{');
+		WriteDoublingBraces(expr.Suffix);
 		WriteChar('"');
 	}
 

--- a/GenPy.fu
+++ b/GenPy.fu
@@ -434,12 +434,12 @@ public class GenPy : GenPySwift
 	{
 		Write("f\"");
 		foreach (FuInterpolatedPart part in expr.Parts) {
-			WriteDoubling(part.Prefix, '{');
+			WriteDoublingBraces(part.Prefix);
 			WriteChar('{');
 			part.Argument.Accept(this, FuPriority.Argument);
 			WritePyFormat(part);
 		}
-		WriteDoubling(expr.Suffix, '{');
+		WriteDoublingBraces(expr.Suffix);
 		WriteChar('"');
 	}
 

--- a/libfut.cpp
+++ b/libfut.cpp
@@ -8823,6 +8823,15 @@ void GenBase::writeDoubling(std::string_view s, int doubled)
 	}
 }
 
+void GenBase::writeDoublingBraces(std::string_view s)
+{
+	for (int c : s) {
+		if (c == '{' || c == '}')
+			writeChar(c);
+		writeChar(c);
+	}
+}
+
 void GenBase::writePrintfWidth(const FuInterpolatedPart * part)
 {
 	if (part->widthExpr != nullptr)
@@ -15666,11 +15675,11 @@ void GenCpp::visitInterpolatedString(const FuInterpolatedString * expr, FuPriori
 	include("format");
 	write("std::format(\"");
 	for (const FuInterpolatedPart &part : expr->parts) {
-		writeDoubling(part.prefix, '{');
+		writeDoublingBraces(part.prefix);
 		writeChar('{');
 		writePyFormat(&part);
 	}
-	writeDoubling(expr->suffix, '{');
+	writeDoublingBraces(expr->suffix);
 	writeChar('"');
 	writeInterpolatedStringArgs(expr);
 	writeChar(')');
@@ -18121,7 +18130,7 @@ void GenCs::visitInterpolatedString(const FuInterpolatedString * expr, FuPriorit
 	}
 	write("$\"");
 	for (const FuInterpolatedPart &part : expr->parts) {
-		writeDoubling(part.prefix, '{');
+		writeDoublingBraces(part.prefix);
 		writeChar('{');
 		if (part.format == 'U' || part.format == 'u')
 			writeCall("char.ConvertFromUtf32", part.argument.get());
@@ -18139,7 +18148,7 @@ void GenCs::visitInterpolatedString(const FuInterpolatedString * expr, FuPriorit
 		}
 		writeChar('}');
 	}
-	writeDoubling(expr->suffix, '{');
+	writeDoublingBraces(expr->suffix);
 	writeChar('"');
 }
 
@@ -26510,12 +26519,12 @@ void GenPy::visitInterpolatedString(const FuInterpolatedString * expr, FuPriorit
 {
 	write("f\"");
 	for (const FuInterpolatedPart &part : expr->parts) {
-		writeDoubling(part.prefix, '{');
+		writeDoublingBraces(part.prefix);
 		writeChar('{');
 		part.argument->accept(this, FuPriority::argument);
 		writePyFormat(&part);
 	}
-	writeDoubling(expr->suffix, '{');
+	writeDoublingBraces(expr->suffix);
 	writeChar('"');
 }
 

--- a/libfut.cs
+++ b/libfut.cs
@@ -8205,6 +8205,15 @@ namespace Fusion
 			}
 		}
 
+		protected void WriteDoublingBraces(string s)
+		{
+			foreach (int c in s) {
+				if (c == '{' || c == '}')
+					WriteChar(c);
+				WriteChar(c);
+			}
+		}
+
 		protected virtual void WritePrintfWidth(FuInterpolatedPart part)
 		{
 			if (part.WidthExpr != null)
@@ -15168,11 +15177,11 @@ namespace Fusion
 			Include("format");
 			Write("std::format(\"");
 			foreach (FuInterpolatedPart part in expr.Parts) {
-				WriteDoubling(part.Prefix, '{');
+				WriteDoublingBraces(part.Prefix);
 				WriteChar('{');
 				WritePyFormat(part);
 			}
-			WriteDoubling(expr.Suffix, '{');
+			WriteDoublingBraces(expr.Suffix);
 			WriteChar('"');
 			WriteInterpolatedStringArgs(expr);
 			WriteChar(')');
@@ -17760,7 +17769,7 @@ namespace Fusion
 			}
 			Write("$\"");
 			foreach (FuInterpolatedPart part in expr.Parts) {
-				WriteDoubling(part.Prefix, '{');
+				WriteDoublingBraces(part.Prefix);
 				WriteChar('{');
 				if (part.Format == 'U' || part.Format == 'u')
 					WriteCall("char.ConvertFromUtf32", part.Argument);
@@ -17778,7 +17787,7 @@ namespace Fusion
 				}
 				WriteChar('}');
 			}
-			WriteDoubling(expr.Suffix, '{');
+			WriteDoublingBraces(expr.Suffix);
 			WriteChar('"');
 		}
 
@@ -26630,12 +26639,12 @@ namespace Fusion
 		{
 			Write("f\"");
 			foreach (FuInterpolatedPart part in expr.Parts) {
-				WriteDoubling(part.Prefix, '{');
+				WriteDoublingBraces(part.Prefix);
 				WriteChar('{');
 				part.Argument.Accept(this, FuPriority.Argument);
 				WritePyFormat(part);
 			}
-			WriteDoubling(expr.Suffix, '{');
+			WriteDoublingBraces(expr.Suffix);
 			WriteChar('"');
 		}
 

--- a/libfut.hpp
+++ b/libfut.hpp
@@ -2548,6 +2548,7 @@ protected:
 	virtual void writeTypeAndName(const FuNamedValue * value) = 0;
 	virtual void writeLocalName(const FuSymbol * symbol, FuPriority parent);
 	void writeDoubling(std::string_view s, int doubled);
+	void writeDoublingBraces(std::string_view s);
 	virtual void writePrintfWidth(const FuInterpolatedPart * part);
 	virtual void writePrintfPartFormat(const FuInterpolatedPart * part);
 	void writePrintfFormat(const FuInterpolatedString * expr);

--- a/libfut.js
+++ b/libfut.js
@@ -8658,6 +8658,15 @@ export class GenBase extends FuVisitor
 		}
 	}
 
+	writeDoublingBraces(s)
+	{
+		for (const c of s) {
+			if (c.codePointAt(0) == 123 || c.codePointAt(0) == 125)
+				this.writeChar(c.codePointAt(0));
+			this.writeChar(c.codePointAt(0));
+		}
+	}
+
 	writePrintfWidth(part)
 	{
 		if (part.widthExpr != null)
@@ -15731,11 +15740,11 @@ export class GenCpp extends GenCCpp
 		this.include("format");
 		this.write("std::format(\"");
 		for (const part of expr.parts) {
-			this.writeDoubling(part.prefix, 123);
+			this.writeDoublingBraces(part.prefix);
 			this.writeChar(123);
 			this.writePyFormat(part);
 		}
-		this.writeDoubling(expr.suffix, 123);
+		this.writeDoublingBraces(expr.suffix);
 		this.writeChar(34);
 		this.writeInterpolatedStringArgs(expr);
 		this.writeChar(41);
@@ -18373,7 +18382,7 @@ export class GenCs extends GenTyped
 		}
 		this.write("$\"");
 		for (const part of expr.parts) {
-			this.writeDoubling(part.prefix, 123);
+			this.writeDoublingBraces(part.prefix);
 			this.writeChar(123);
 			if (part.format == 85 || part.format == 117)
 				this.writeCall("char.ConvertFromUtf32", part.argument);
@@ -18391,7 +18400,7 @@ export class GenCs extends GenTyped
 			}
 			this.writeChar(125);
 		}
-		this.writeDoubling(expr.suffix, 123);
+		this.writeDoublingBraces(expr.suffix);
 		this.writeChar(34);
 	}
 
@@ -27356,12 +27365,12 @@ export class GenPy extends GenPySwift
 	{
 		this.write("f\"");
 		for (const part of expr.parts) {
-			this.writeDoubling(part.prefix, 123);
+			this.writeDoublingBraces(part.prefix);
 			this.writeChar(123);
 			part.argument.accept(this, FuPriority.ARGUMENT);
 			this.writePyFormat(part);
 		}
-		this.writeDoubling(expr.suffix, 123);
+		this.writeDoublingBraces(expr.suffix);
 		this.writeChar(34);
 	}
 

--- a/test/OpAddStringInterpolated.fu
+++ b/test/OpAddStringInterpolated.fu
@@ -2,7 +2,8 @@ public static class Test
 {
 	public static bool Run()
 	{
-		const int answer = 42;
-		return "The answer " + $"is {answer}" == "The answer is 42";
+		int answer = 42;
+		return "The answer " + $"is {answer}" == "The answer is 42"
+			&& "{\"answer\":" + $"{answer}" + "}" == "{\"answer\":42}";
 	}
 }


### PR DESCRIPTION
This fixes a scenario where start and end braces in interpolated strings do not work in C++ due to only the first brace being escaped and not the last.
The problem should also affect C# and Python, but I haven't confirmed the fix there.

I encountered this when trying to encode a JSON file (I can provide the example if needed).
A repro was added into `test/OpAddStringInterpolated.fu`. Not sure if that's the right place for it, so let me know.

While verifying the test, I noticed that if the `int answer` is const then the whole test gets evaluated at compile time so that went into its own issue: #255